### PR TITLE
Calculate tangent to bezier curve at a point

### DIFF
--- a/beziers.scad
+++ b/beziers.scad
@@ -99,6 +99,29 @@ function bez_point(curve,u)=
 			u
 		);
 
+// Function: bez_tangent()
+// Usage:
+//   bez_tangent(curve, u)
+// Description:
+//   Calculate the tangent vector at a point on a bezier curve.
+// Arguments:
+//   curve = The list of endpoints and control points for this bezier segment.
+//   u = The proportion of the way along the curve to find the point of.  0<=`u`<=1
+// Example(2D): Cubic (degree 3) bezier tangent
+//   bez = [[0,0], [5,35], [60,-25], [80,0]];
+//   point = bez_point(bez, 0.2);
+//   tangent = bez_tangent(bez, 0.2) * 10;
+//   trace_bezier(bez, N=len(bez)-1);
+//   color("red") translate(point) extrude_from_to(-tangent, tangent) circle(d=.5);
+function bez_tangent(curve, u) = (
+	len(curve) <= 2
+		? normalize(u * (curve[1] - curve[0]))
+		: bez_tangent([
+			for(i=[0:len(curve)-2])
+				curve[i] * (1 - u) +
+				curve[i + 1] * u
+		], u)
+);
 
 // Function: bezier_segment_closest_point()
 // Usage:


### PR DESCRIPTION
I added a function to calculate the tangent vector at a given distance along a given bezier curve. It's based on the `bez_point` function but stops recursing at the second degree and returns the difference between the two points.

_Output from example usage:_
<img width="514" alt="Screen Shot 2020-10-05 at 10 10 01 PM" src="https://user-images.githubusercontent.com/1165066/95151282-48831a00-0758-11eb-8f58-333ce35fd674.png">


Ultimately I'd like to have a function that returns a transformation matrix that can be applied to a point traveling along the curve, but I'm not sure if I'd inadvertently be reproducing existing functionality like `extrude_bezier_along_bezier`.